### PR TITLE
Add README for the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Maybe Finance Home Assistant Addon
+
+## Overview
+
+This repository contains the Maybe Finance addon for Home Assistant. Maybe Finance is a personal finance management application that helps you track your expenses, income, and investments. This addon allows you to run Maybe Finance within Home Assistant, providing seamless integration into your smart home ecosystem.
+
+## Features
+
+- Track income and expenses
+- Monitor investments
+- Self-hosted for privacy and control
+
+## Installation Guide
+
+[Full README here](./maybe_finance/README.md)
+
+## Links
+
+- [Main Maybe Finance GitHub Repository](https://github.com/maybe-finance/maybe)
+
+


### PR DESCRIPTION
Fixes #4

Add a general README for the repository.

* Provide an overview of the Maybe Finance Home Assistant Addon.
* List features of the addon.
* Include an installation guide with a link to the full README.
* Add links to the main Maybe Finance GitHub repository.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/M123-dev/maybe_finance_hass/pull/5?shareId=01ec860d-d127-4493-9cfe-2515c8c20485).