### PR TITLE
chore: Update Maybe Finance to latest commit

### DIFF
--- a/maybe_finance/Dockerfile
+++ b/maybe_finance/Dockerfile
@@ -4,7 +4,7 @@ FROM --platform=${BUILD_ARCH} alpine/git AS clone
 WORKDIR /src
 RUN apk add --no-cache git && \
     git clone https://github.com/maybe-finance/maybe.git . && \
-    git checkout e9b29f67268e326a8ed3ec53d07351187cc31fd7
+    git checkout 79e1a2c0ffd5191fe6c040da68a311e1c1e6beb4
 
 # Stage 2: Base image with necessary dependencies
 ARG BUILD_ARCH

--- a/maybe_finance/config.yaml
+++ b/maybe_finance/config.yaml
@@ -47,5 +47,5 @@ options:
 #  dockerfile: Dockerfile
 #  args:
 #    BUILD_ARCH: "{arch}"
-version: 0.3.3
+version: 0.3.4
 image: ghcr.io/m123-dev/{arch}-maybe_finance_homeassistant


### PR DESCRIPTION
This PR updates the Maybe Finance repository to the latest commit ($LATEST_COMMIT) 
and bumps the patch version to **0.3.4**.