### PR TITLE
chore: Update Maybe Finance to latest commit

### DIFF
--- a/maybe_finance/Dockerfile
+++ b/maybe_finance/Dockerfile
@@ -5,7 +5,7 @@ FROM $BUILD_FROM AS clone
 WORKDIR /src
 RUN apk add --no-cache git && \
     git clone https://github.com/maybe-finance/maybe.git . && \
-    git checkout e9b29f67268e326a8ed3ec53d07351187cc31fd7
+    git checkout 79e1a2c0ffd5191fe6c040da68a311e1c1e6beb4
 
 # Stage 2: Base image with necessary dependencies
 FROM --platform=${BUILD_ARCH} ruby:3.4.1-slim AS base

--- a/maybe_finance/config.yaml
+++ b/maybe_finance/config.yaml
@@ -45,7 +45,7 @@ options:
   rails_force_ssl: false
   rails_assume_ssl: false
   good_job_execution_mode: "async"
-version: 0.3.4
+version: 0.3.5
 #build:
 #  dockerfile: Dockerfile
 #  args:


### PR DESCRIPTION
This PR updates the Maybe Finance repository to the latest commit
and bumps the patch version to **0.3.5**.