### PR TITLE
chore: Update Maybe Finance to latest commit

### DIFF
--- a/maybe_finance/Dockerfile
+++ b/maybe_finance/Dockerfile
@@ -13,7 +13,7 @@ FROM --platform=${BUILD_ARCH} alpine/git AS clone
 WORKDIR /src
 RUN apk add --no-cache git && \
     git clone https://github.com/maybe-finance/maybe.git . && \
-    git checkout 8539ac7dec4c713fc6f3b92abf05108a261bd194
+    git checkout fd95f8d2bd46505f77e6ef34b73d3fd3b4191655
 
 ############################
 # Stage 2: Base image with necessary dependencies

--- a/maybe_finance/Dockerfile
+++ b/maybe_finance/Dockerfile
@@ -13,7 +13,7 @@ FROM --platform=${BUILD_ARCH} alpine/git AS clone
 WORKDIR /src
 RUN apk add --no-cache git && \
     git clone https://github.com/maybe-finance/maybe.git . && \
-    git checkout c620d1fc1e53aea2f0db6388e67590485b2fd6d7
+    git checkout 8539ac7dec4c713fc6f3b92abf05108a261bd194
 
 ############################
 # Stage 2: Base image with necessary dependencies

--- a/maybe_finance/config.yaml
+++ b/maybe_finance/config.yaml
@@ -45,7 +45,7 @@ options:
   rails_force_ssl: false
   rails_assume_ssl: false
   good_job_execution_mode: "async"
-version: 0.3.5
+version: 0.3.6
 #build:
 #  dockerfile: Dockerfile
 #  args:

--- a/maybe_finance/config.yaml
+++ b/maybe_finance/config.yaml
@@ -45,7 +45,7 @@ options:
   rails_force_ssl: false
   rails_assume_ssl: false
   good_job_execution_mode: "async"
-version: 0.3.6
+version: 0.4.1
 #build:
 #  dockerfile: Dockerfile
 #  args:


### PR DESCRIPTION
This PR updates the Maybe Finance repository to the latest commit
and bumps the patch version to **0.3.6**.