### PR TITLE
chore: Update Maybe Finance to 0.4.13

### DIFF
--- a/maybe_finance/Dockerfile
+++ b/maybe_finance/Dockerfile
@@ -13,7 +13,7 @@ FROM --platform=${BUILD_ARCH} alpine/git AS clone
 WORKDIR /src
 RUN apk add --no-cache git && \
     git clone https://github.com/maybe-finance/maybe.git . && \
-    git checkout c66401dc0f58d9300f37cd0eb050f54abf68712b
+    git checkout 7b751ac7cae4ca1f44aa14b453a088636886490c
 
 ############################
 # Stage 2: Base image with necessary dependencies

--- a/maybe_finance/config.yaml
+++ b/maybe_finance/config.yaml
@@ -47,7 +47,7 @@ options:
   rails_assume_ssl: false
   good_job_execution_mode: "async"
   require_invite_code: true
-version: 0.4.12
+version: 0.4.13
 #build:
 #  dockerfile: Dockerfile
 #  args:


### PR DESCRIPTION
This PR updates the Maybe Finance repository to the latest commit
and bumps the patch version to **0.4.13**.