### PR TITLE
chore: Update Maybe Finance to 0.4.18

### DIFF
--- a/maybe_finance/Dockerfile
+++ b/maybe_finance/Dockerfile
@@ -13,7 +13,7 @@ FROM --platform=${BUILD_ARCH} alpine/git AS clone
 WORKDIR /src
 RUN apk add --no-cache git && \
     git clone https://github.com/maybe-finance/maybe.git . && \
-    git checkout a7db914005853b06036f0f49d365a32e2f986901
+    git checkout 02bfa9f25162452533629cd2749337cc2c505dac
 
 ############################
 # Stage 2: Base image with necessary dependencies

--- a/maybe_finance/config.yaml
+++ b/maybe_finance/config.yaml
@@ -47,7 +47,7 @@ options:
   rails_assume_ssl: false
   good_job_execution_mode: "async"
   require_invite_code: true
-version: 0.4.17
+version: 0.4.18
 #build:
 #  dockerfile: Dockerfile
 #  args:


### PR DESCRIPTION
This PR updates the Maybe Finance repository to the latest commit
and bumps the patch version to **0.4.18**.