### PR TITLE
chore: Update Maybe Finance to 0.4.20

### DIFF
--- a/maybe_finance/Dockerfile
+++ b/maybe_finance/Dockerfile
@@ -13,7 +13,7 @@ FROM --platform=${BUILD_ARCH} alpine/git AS clone
 WORKDIR /src
 RUN apk add --no-cache git && \
     git clone https://github.com/maybe-finance/maybe.git . && \
-    git checkout 52d170e36c3b84c4658213ccb7ef86095ec2eb81
+    git checkout d22a16d8dee357308a3b871d9cd4d09c7f3857c9
 
 ############################
 # Stage 2: Base image with necessary dependencies

--- a/maybe_finance/config.yaml
+++ b/maybe_finance/config.yaml
@@ -47,7 +47,7 @@ options:
   rails_assume_ssl: false
   good_job_execution_mode: "async"
   require_invite_code: true
-version: 0.4.19
+version: 0.4.20
 #build:
 #  dockerfile: Dockerfile
 #  args:


### PR DESCRIPTION
This PR updates the Maybe Finance repository to the latest commit
and bumps the patch version to **0.4.20**.