### PR TITLE
chore: Update Maybe Finance to 0.5.7

### DIFF
--- a/maybe_finance/Dockerfile
+++ b/maybe_finance/Dockerfile
@@ -13,7 +13,7 @@ FROM --platform=${BUILD_ARCH} alpine/git AS clone
 WORKDIR /src
 RUN apk add --no-cache git && \
     git clone https://github.com/maybe-finance/maybe.git . && \
-    git checkout 18148acd695f46fa81c76e139a1ef97296380755
+    git checkout 662f2c04ce905c8d92d82204bf95662bbebb19d5
 
 ############################
 # Stage 2: Base image with necessary dependencies

--- a/maybe_finance/config.yaml
+++ b/maybe_finance/config.yaml
@@ -53,7 +53,7 @@ options:
   rails_assume_ssl: false
   good_job_execution_mode: "async"
   require_invite_code: true
-version: 0.5.6
+version: 0.5.7
 #build:
 #  dockerfile: Dockerfile
 #  args:


### PR DESCRIPTION
This PR updates the Maybe Finance repository to the latest commit
and bumps the patch version to **0.5.7**.